### PR TITLE
Create qbittorrent-4.3.4.1.client

### DIFF
--- a/resources/clients/qbittorrent-4.3.4.1.client
+++ b/resources/clients/qbittorrent-4.3.4.1.client
@@ -1,0 +1,30 @@
+{
+    "keyGenerator": {
+        "algorithm": {
+            "type": "HASH_NO_LEADING_ZERO",
+            "length": 8
+        },
+        "refreshOn": "TORRENT_PERSISTENT",
+        "keyCase": "upper"
+    },
+    "peerIdGenerator": {
+        "algorithm": {
+            "type": "REGEX",
+            "pattern": "-qB4341-[A-Za-z0-9_~\\(\\)\\!\\.\\*-]{12}"
+        },
+        "refreshOn": "NEVER",
+        "shouldUrlEncode": false
+    },
+    "urlEncoder": {
+        "encodingExclusionPattern": "[A-Za-z0-9_~\\(\\)\\!\\.\\*-]",
+        "encodedHexCase": "lower"
+    },
+    "query": "info_hash={infohash}&peer_id={peerid}&port={port}&uploaded={uploaded}&downloaded={downloaded}&left={left}&corrupt=0&key={key}&event={event}&numwant={numwant}&compact=1&no_peer_id=1&supportcrypto=1&redundant=0",
+    "numwant": 200,
+    "numwantOnStop": 0,
+    "requestHeaders": [
+        { "name": "User-Agent", "value": "qBittorrent/4.3.4.1" },
+        { "name": "Accept-Encoding", "value": "gzip" },
+        { "name": "Connection", "value": "close" }
+    ]
+}


### PR DESCRIPTION
Another release. I skipped 4.3.4 due to there being a bug with 4.3.4 that the qbittorrent WebUI no longer worked, which they fixed with 4.3.4.1 release