### PR TITLE
Improve CLI logging readability

### DIFF
--- a/src/main/java/org/araymond/joal/core/torrent/torrent/InfoHash.java
+++ b/src/main/java/org/araymond/joal/core/torrent/torrent/InfoHash.java
@@ -4,10 +4,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.regex.Pattern;
-
-import static org.apache.commons.lang3.StringUtils.EMPTY;
-
 @ToString
 @EqualsAndHashCode(of = "infoHash")
 @Getter
@@ -15,11 +11,21 @@ public class InfoHash {
     private final String infoHash;
     private final String humanReadable;
 
-    private static final Pattern INVISIBLE_CTRL_CHARS_PTRN = Pattern.compile("\\p{C}");
+    private static final char[] HEX_CHARS = "0123456789abcdef".toCharArray();
 
     public InfoHash(final byte[] bytes) {
         this.infoHash = new String(bytes, MockedTorrent.BYTE_ENCODING);
-        this.humanReadable = INVISIBLE_CTRL_CHARS_PTRN.matcher(infoHash).replaceAll(EMPTY);
+        this.humanReadable = bytesToHex(bytes);
+    }
+
+    private static String bytesToHex(final byte[] bytes) {
+        final char[] hexChars = new char[bytes.length * 2];
+        for (int i = 0; i < bytes.length; i++) {
+            final int v = bytes[i] & 0xFF;
+            hexChars[i * 2] = HEX_CHARS[v >>> 4];
+            hexChars[i * 2 + 1] = HEX_CHARS[v & 0x0F];
+        }
+        return new String(hexChars);
     }
 
     public String value() {

--- a/src/main/java/org/araymond/joal/core/ttorrent/client/announcer/Announcer.java
+++ b/src/main/java/org/araymond/joal/core/ttorrent/client/announcer/Announcer.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 
 import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
+import static org.apache.commons.io.FileUtils.byteCountToDisplaySize;
 
 @Slf4j
 public class Announcer implements AnnouncerFacade {
@@ -67,8 +68,10 @@ public class Announcer implements AnnouncerFacade {
                     this.announceDataAccessor.getHttpRequestQueryForTorrent(this.torrent.getTorrentInfoHash(), event),
                     this.announceDataAccessor.getHttpHeadersForTorrent()
             );
-            log.info("{} has announced successfully. Response: {} seeders, {} leechers, {}s interval",
-                    this.torrent.getTorrentInfoHash().getHumanReadable(), responseMessage.getSeeders(), responseMessage.getLeechers(), responseMessage.getInterval());
+            log.info("{} has announced successfully. Response: {} seeders, {} leechers, {}s interval. Uploaded: {}, Speed: {}/s",
+                    this.torrent.getTorrentInfoHash().getHumanReadable(), responseMessage.getSeeders(), responseMessage.getLeechers(), responseMessage.getInterval(),
+                    byteCountToDisplaySize(announceDataAccessor.getUploaded(this.torrent.getTorrentInfoHash())),
+                    byteCountToDisplaySize(announceDataAccessor.getSpeedInBytesPerSecond(this.torrent.getTorrentInfoHash())));
 
             this.reportedUploadBytes = announceDataAccessor.getUploaded(this.torrent.getTorrentInfoHash());
             this.lastKnownInterval = responseMessage.getInterval();

--- a/src/main/java/org/araymond/joal/core/ttorrent/client/announcer/request/AnnounceDataAccessor.java
+++ b/src/main/java/org/araymond/joal/core/ttorrent/client/announcer/request/AnnounceDataAccessor.java
@@ -2,7 +2,8 @@ package org.araymond.joal.core.ttorrent.client.announcer.request;
 
 import com.turn.ttorrent.common.protocol.TrackerMessage.AnnounceRequestMessage.RequestEvent;
 import lombok.RequiredArgsConstructor;
-import org.araymond.joal.core.bandwith.BandwidthDispatcherFacade;
+import org.araymond.joal.core.bandwith.BandwidthDispatcher;
+import org.araymond.joal.core.bandwith.Speed;
 import org.araymond.joal.core.client.emulated.BitTorrentClient;
 import org.araymond.joal.core.torrent.torrent.InfoHash;
 import org.araymond.joal.core.ttorrent.client.ConnectionHandler;
@@ -10,11 +11,13 @@ import org.araymond.joal.core.ttorrent.client.ConnectionHandler;
 import java.util.Map;
 import java.util.Set;
 
+import static java.util.Optional.ofNullable;
+
 @RequiredArgsConstructor
 public class AnnounceDataAccessor {
 
     private final BitTorrentClient bitTorrentClient;
-    private final BandwidthDispatcherFacade bandwidthDispatcher;
+    private final BandwidthDispatcher bandwidthDispatcher;
     private final ConnectionHandler connectionHandler;
 
     public String getHttpRequestQueryForTorrent(final InfoHash infoHash, final RequestEvent event) {
@@ -27,5 +30,11 @@ public class AnnounceDataAccessor {
 
     public long getUploaded(final InfoHash infoHash) {
         return this.bandwidthDispatcher.getSeedStatForTorrent(infoHash).getUploaded();
+    }
+
+    public long getSpeedInBytesPerSecond(final InfoHash infoHash) {
+        return ofNullable(this.bandwidthDispatcher.getSpeedMap().get(infoHash))
+                .map(Speed::getBytesPerSecond)
+                .orElse(0L);
     }
 }

--- a/src/test/java/org/araymond/joal/core/torrent/torrent/InfoHashTest.java
+++ b/src/test/java/org/araymond/joal/core/torrent/torrent/InfoHashTest.java
@@ -33,10 +33,10 @@ public class InfoHashTest {
     }
 
     @Test
-    public void shouldRemoveNonHumanReadableChars() {
-        final InfoHash infoHash = new InfoHash("a\u0001b\u0001\u0001cc\u0002".getBytes());
+    public void shouldReturnHexEncodedHumanReadable() {
+        final InfoHash infoHash = new InfoHash(new byte[] {(byte) 0xab, (byte) 0xcd, (byte) 0x12, (byte) 0x34});
 
-        assertThat(infoHash.getHumanReadable()).isEqualTo("abcc");
+        assertThat(infoHash.getHumanReadable()).isEqualTo("abcd1234");
     }
 
 }

--- a/src/test/java/org/araymond/joal/core/ttorrent/client/announcer/response/BandwidthDispatcherNotifierTest.java
+++ b/src/test/java/org/araymond/joal/core/ttorrent/client/announcer/response/BandwidthDispatcherNotifierTest.java
@@ -75,10 +75,12 @@ public class BandwidthDispatcherNotifierTest {
         final SuccessAnnounceResponse successAnnounceResponse = mock(SuccessAnnounceResponse.class);
         doReturn(10).when(successAnnounceResponse).getLeechers();
         doReturn(15).when(successAnnounceResponse).getSeeders();
+        doReturn(100).when(successAnnounceResponse).getInterval();
         notifier.onAnnounceStartSuccess(announcer, successAnnounceResponse);
 
         Mockito.verify(dispatcher, times(1)).registerTorrent(ArgumentMatchers.eq(infoHash));
         Mockito.verify(dispatcher, times(1)).updateTorrentPeers(ArgumentMatchers.eq(infoHash), ArgumentMatchers.eq(15), ArgumentMatchers.eq(10));
+        Mockito.verify(dispatcher, times(1)).getSpeedMap();
         Mockito.verifyNoMoreInteractions(dispatcher);
     }
 
@@ -95,9 +97,11 @@ public class BandwidthDispatcherNotifierTest {
         final SuccessAnnounceResponse successAnnounceResponse = mock(SuccessAnnounceResponse.class);
         doReturn(10).when(successAnnounceResponse).getLeechers();
         doReturn(15).when(successAnnounceResponse).getSeeders();
+        doReturn(100).when(successAnnounceResponse).getInterval();
         notifier.onAnnounceRegularSuccess(announcer, successAnnounceResponse);
 
         Mockito.verify(dispatcher, times(1)).updateTorrentPeers(ArgumentMatchers.eq(infoHash), ArgumentMatchers.eq(15), ArgumentMatchers.eq(10));
+        Mockito.verify(dispatcher, times(1)).getSpeedMap();
         Mockito.verifyNoMoreInteractions(dispatcher);
     }
 


### PR DESCRIPTION
As a CLI user, the announce logs were hard to read due to garbled info hashes and missing upload stats.

Before:

```
[INFO ] o.a.j.c.t.c.a.Announcer: ¨ª:©a6ÅT'¦;ué has announced successfully. Response: 333 seeders, 35 leechers, 2400s interval
```

After:

```
[INFO ] o.a.j.c.t.c.a.Announcer: 3fb9c456118d812e45154a42413d97cd787e416b has announced successfully. Response: 381 seeders, 72 leechers, 2400s interval. Uploaded: 0 bytes, Speed: 0 bytes/s
[INFO ] o.a.j.c.t.c.a.r.BandwidthDispatcherNotifier: 3fb9c456118d812e45154a42413d97cd787e416b will upload 76 GB at 32 MB/s for next 2400s
```